### PR TITLE
Added windows 10 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+
+.vs/

--- a/KeyboardLayoutMonitor/ColorSettingsController.cs
+++ b/KeyboardLayoutMonitor/ColorSettingsController.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace KeyboardLayoutMonitor
@@ -8,7 +12,68 @@ namespace KeyboardLayoutMonitor
 		private static IntPtr currentLanguageHanlder = IntPtr.Zero;
 		private static readonly InputLanguageCollection installedInputLanguages = InputLanguage.InstalledInputLanguages;
 
-		public static void SetColor(IntPtr layoutHandle, Settings settings)
+        private static bool isWin10;
+        private static bool findTaskbarHandles = true;
+        private static bool runApplyTask = false;
+        private static List<IntPtr> taskbarHandles = new List<IntPtr>();
+        private static Win10Api.AccentPolicy accentPolicy;
+        private static Task applyTask;
+        private static void ApplyToAllTaskbars()
+        {
+            while (runApplyTask)
+            {
+                if (findTaskbarHandles)
+                {
+                    taskbarHandles.Clear();
+
+                    var primaryBar = Win10Api.FindWindow("Shell_TrayWnd", null);
+
+                    taskbarHandles.Add(primaryBar);
+
+                    IntPtr secondaryBar = IntPtr.Zero;
+
+                    while (true)
+                    {
+                        secondaryBar = Win10Api.FindWindowEx(IntPtr.Zero, secondaryBar, "Shell_SecondaryTrayWnd", "");
+                        if (secondaryBar == IntPtr.Zero) { break; }
+                        else
+                        {
+                            taskbarHandles.Add(secondaryBar);
+                        }
+                    }
+
+                    findTaskbarHandles = false;
+                }
+
+                foreach (var handle in taskbarHandles)
+                {
+                    int sizeOfPolicy = Marshal.SizeOf(accentPolicy);
+                    IntPtr policyPtr = Marshal.AllocHGlobal(sizeOfPolicy);
+                    Marshal.StructureToPtr(accentPolicy, policyPtr, false);
+
+                    Win10Api.WinCompatTrData data = new Win10Api.WinCompatTrData(Win10Api.WindowCompositionAttribute.WCA_ACCENT_POLICY, policyPtr, sizeOfPolicy);
+
+                    Win10Api.SetWindowCompositionAttribute(handle, ref data);
+
+                    Marshal.FreeHGlobal(policyPtr);
+                }
+
+                Thread.Sleep(10);
+            }
+        }
+
+        public static void InitialiseWin10(Settings settings)
+        {
+            isWin10 = true;
+            accentPolicy.AccentState = Win10Api.AccentState.ACCENT_ENABLE_GRADIENT;
+            accentPolicy.GradientColor = settings.Win10DefaultLayoutColorScheme;
+
+            runApplyTask = true;
+            applyTask = new Task(() => ApplyToAllTaskbars());
+            applyTask.Start();
+        }
+
+        public static void SetColor(IntPtr layoutHandle, Settings settings)
 		{
 			if (layoutHandle == currentLanguageHanlder) return;
 			currentLanguageHanlder = layoutHandle;
@@ -23,16 +88,32 @@ namespace KeyboardLayoutMonitor
 				}
 			}
 
-			if (languageName == null) return;
+			
+            try
+            {
+                if (isWin10)
+                {
+                    if (languageName == settings.DefaultLayoutName)
+                    {
+                        accentPolicy.GradientColor = settings.Win10DefaultLayoutColorScheme;
+                    }
+                    else
+                    {
+                        accentPolicy.GradientColor = settings.Win10AlternativeLayoutColorScheme;
+                    }
+                }
+                else
+                {
+                    if (languageName == null) return;
 
-			try
-			{
-				if (!DwmApi.DwmIsCompositionEnabled())
-					return;
-				var colorizationParams = (languageName == settings.DefaultLayoutName)
-					? settings.DefaultLayoutColorScheme
-					: settings.AlternativeLayoutColorScheme;
-				DwmApi.DwmSetColorizationParameters(ref colorizationParams, 0);
+                    if (!DwmApi.DwmIsCompositionEnabled())
+                        return;
+                    var colorizationParams = (languageName == settings.DefaultLayoutName)
+                        ? settings.DefaultLayoutColorScheme
+                        : settings.AlternativeLayoutColorScheme;
+                    DwmApi.DwmSetColorizationParameters(ref colorizationParams, 0);
+                }
+				
 			}
 			catch (Exception ex)
 			{

--- a/KeyboardLayoutMonitor/KeyboardLayoutMonitor.csproj
+++ b/KeyboardLayoutMonitor/KeyboardLayoutMonitor.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>KeyboardLayoutMonitor</RootNamespace>
     <AssemblyName>KeyboardLayoutMonitor</AssemblyName>
-    <TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -32,6 +32,7 @@
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation />
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -50,6 +51,9 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -71,6 +75,7 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Win10Api.cs" />
     <EmbeddedResource Include="MainForm.resx">
       <DependentUpon>MainForm.cs</DependentUpon>
     </EmbeddedResource>
@@ -84,6 +89,8 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
+    <None Include="app.config" />
+    <None Include="app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/KeyboardLayoutMonitor/MainForm.cs
+++ b/KeyboardLayoutMonitor/MainForm.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Reflection;
 using System.Windows.Forms;
@@ -15,6 +16,7 @@ namespace KeyboardLayoutMonitor
 		private static Process hookerProcess64;
 		private bool realClose;
 		private Settings settings = new Settings();
+        private bool isWin10;
 
 		private static void ApplicationOnApplicationExit(object sender, EventArgs args)
 		{
@@ -113,18 +115,35 @@ namespace KeyboardLayoutMonitor
 		{
 			foreach (InputLanguage language in InputLanguage.InstalledInputLanguages)
 			{
-				if (language.LayoutName == comboBoxLanguages.SelectedText)
+				if (language.LayoutName == (string)comboBoxLanguages.SelectedItem)
 					settings.DefaultLayoutName = language.Culture.ThreeLetterWindowsLanguageName;
 			}
 		}
 
-		private void buttonPickDefaultLayoutColor_Click(object sender, EventArgs e)
+        public static int GetWin10TaskbarColorAsInt()
+        {
+            string keyName = "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Accent";
+            byte[] bytes = (byte[])Microsoft.Win32.Registry.GetValue(keyName, "AccentPalette", null);
+
+            var accentColor = Color.FromArgb(bytes[23], bytes[20], bytes[21], bytes[22]);
+
+            return BitConverter.ToInt32(new byte[] { accentColor.R, accentColor.G, accentColor.B, 0 }, 0);
+        }
+
+        private void buttonPickDefaultLayoutColor_Click(object sender, EventArgs e)
 		{
 			try
 			{
-				DwmApi.WDM_COLORIZATION_PARAMS colorizationParams;
-				DwmApi.DwmGetColorizationParameters(out colorizationParams);
-				settings.DefaultLayoutColorScheme = colorizationParams;
+                if (isWin10)
+                {
+                    settings.Win10DefaultLayoutColorScheme = GetWin10TaskbarColorAsInt();
+                }
+                else
+                {
+                    DwmApi.WDM_COLORIZATION_PARAMS colorizationParams;
+                    DwmApi.DwmGetColorizationParameters(out colorizationParams);
+                    settings.DefaultLayoutColorScheme = colorizationParams;
+                }
 			}
 			catch (Exception ex)
 			{
@@ -137,9 +156,16 @@ namespace KeyboardLayoutMonitor
 		{
 			try
 			{
-				DwmApi.WDM_COLORIZATION_PARAMS colorizationParams;
-				DwmApi.DwmGetColorizationParameters(out colorizationParams);
-				settings.AlternativeLayoutColorScheme = colorizationParams;
+                if (isWin10)
+                {
+                    settings.Win10AlternativeLayoutColorScheme = GetWin10TaskbarColorAsInt();                    
+                }
+                else
+                {
+                    DwmApi.WDM_COLORIZATION_PARAMS colorizationParams;
+                    DwmApi.DwmGetColorizationParameters(out colorizationParams);
+                    settings.AlternativeLayoutColorScheme = colorizationParams;
+                }
 			}
 			catch (Exception ex)
 			{
@@ -215,13 +241,21 @@ namespace KeyboardLayoutMonitor
 		{
 			LoadOrCreateDefaultSettings();
 
-			if (Environment.OSVersion.Version.Major < 6)
+            var osVersionMajor = Environment.OSVersion.Version.Major;
+            
+            if (osVersionMajor < 6)
 			{
 				const string errorMessage = "Операцинные системы без Windows Aero не поддерживаются";
 				MessageBox.Show(errorMessage, "Ошибка при запуске", MessageBoxButtons.OK, MessageBoxIcon.Error);
 				Environment.FailFast(errorMessage);
 				return;
 			}
+
+            if (osVersionMajor == 10)
+            {
+                isWin10 = true;
+                ColorSettingsController.InitialiseWin10(settings);
+            }
 
 			try
 			{

--- a/KeyboardLayoutMonitor/Settings.cs
+++ b/KeyboardLayoutMonitor/Settings.cs
@@ -10,7 +10,10 @@ namespace KeyboardLayoutMonitor
 		public DwmApi.WDM_COLORIZATION_PARAMS DefaultLayoutColorScheme { get; set; }
 		public DwmApi.WDM_COLORIZATION_PARAMS AlternativeLayoutColorScheme { get; set; }
 
-		public static Settings CreateDefaultSettings()
+        public int Win10DefaultLayoutColorScheme { get; set; }
+        public int Win10AlternativeLayoutColorScheme { get; set; }
+
+        public static Settings CreateDefaultSettings()
 		{
 			var result = new Settings {DefaultLayoutName = "ENU"};
 
@@ -40,7 +43,11 @@ namespace KeyboardLayoutMonitor
 
 			result.AlternativeLayoutColorScheme = colorizationParams;
 
-			return result;
+            result.Win10DefaultLayoutColorScheme = 6368045;
+            result.Win10AlternativeLayoutColorScheme = 2773504;
+
+
+            return result;
 		}
 
 		public static byte[] Serialize(Settings settings)
@@ -53,7 +60,11 @@ namespace KeyboardLayoutMonitor
 			stream.Write(buffer, 0, buffer.Length);
 			buffer = SerializeColorizationParams(settings.AlternativeLayoutColorScheme);
 			stream.Write(buffer, 0, buffer.Length);
-			return stream.ToArray();
+            buffer = BitConverter.GetBytes(settings.Win10DefaultLayoutColorScheme);
+            stream.Write(buffer, 0, buffer.Length);
+            buffer = BitConverter.GetBytes(settings.Win10AlternativeLayoutColorScheme);
+            stream.Write(buffer, 0, buffer.Length);
+            return stream.ToArray();
 		}
 
 		public static Settings Deserialize(byte[] serializedSettings)
@@ -88,7 +99,10 @@ namespace KeyboardLayoutMonitor
 					Unknown3 = reader.ReadUInt32()
 				};
 				settings.AlternativeLayoutColorScheme = colorizationParams;
-			}
+
+                settings.Win10DefaultLayoutColorScheme = reader.ReadInt32();
+                settings.Win10AlternativeLayoutColorScheme = reader.ReadInt32();
+            }
 
 			return settings;
 		}

--- a/KeyboardLayoutMonitor/Win10Api.cs
+++ b/KeyboardLayoutMonitor/Win10Api.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace KeyboardLayoutMonitor
+{
+    public static class Win10Api
+    {
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern int SetWindowCompositionAttribute(IntPtr hwnd, ref WinCompatTrData data);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        public static extern IntPtr FindWindowEx(IntPtr parentHandle, IntPtr childAfter, string lclassName, string windowTitle);
+
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct AccentPolicy
+        {
+            public AccentState AccentState;
+            public int AccentFlags;
+            public int GradientColor;
+            public int AnimationId;
+
+            public AccentPolicy(AccentState accentState, int accentFlags, int gradientColor, int animationId)
+            {
+                AccentState = accentState;
+                AccentFlags = accentFlags;
+                GradientColor = gradientColor;
+                AnimationId = animationId;
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct WinCompatTrData
+        {
+            public WindowCompositionAttribute Attribute;
+            public IntPtr Data;
+            public int SizeOfData;
+
+            public WinCompatTrData(WindowCompositionAttribute attribute, IntPtr data, int sizeOfData)
+            {
+                Attribute = attribute;
+                Data = data;
+                SizeOfData = sizeOfData;
+            }
+        }
+        
+        public enum AccentState
+        {
+            ACCENT_DISABLED = 0,
+            ACCENT_ENABLE_GRADIENT = 1,
+            ACCENT_ENABLE_TRANSPARENTGRADIENT = 2,
+            ACCENT_ENABLE_BLURBEHIND = 3,
+            ACCENT_INVALID_STATE = 4
+        }
+
+        public enum WindowCompositionAttribute
+        {
+            WCA_ACCENT_POLICY = 19
+        }
+    }
+}

--- a/KeyboardLayoutMonitor/app.config
+++ b/KeyboardLayoutMonitor/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/KeyboardLayoutMonitor/app.manifest
+++ b/KeyboardLayoutMonitor/app.manifest
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- Параметры манифеста UAC
+             Если вы хотите изменить уровень контроля учетных записей Windows, замените узел 
+             requestedExecutionLevel на один из следующих.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            При указании элемента requestedExecutionLevel будет отключена виртуализация файлов и реестра. 
+            Удалите этот элемент, если виртуализация требуется приложению для обратной
+            совместимости.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Список версий Windows, на которых это приложение было протестировано
+           и будет работать. Раскомментируйте соответствующие элементы, чтобы ОС Windows 
+           автоматически выбрала наиболее совместимое окружение. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+    </application>
+  </compatibility>
+
+  <!-- Указывает, что приложение поддерживает определение DPI и не будет автоматически масштабироваться Windows при более высоких
+       значениях DPI. Приложения Windows Presentation Foundation (WPF) по умолчанию поддерживают определение DPI, им не нужно 
+       специально включать параметр для этого. Для приложений Windows Forms на платформе .NET Framework 4.6, для которых задан этот параметр, необходимо 
+       также задать для "EnableWindowsFormsHighDpiAutoResizing" значение "true" в файле app.config.-->
+  <!--
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+  -->
+
+  <!-- Включите темы для общих элементов управления и диалоговых окон Windows (Windows XP и более поздние версии) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>


### PR DESCRIPTION
Добавил поддержку Windows 10.
Цвет меняется только у панели задач путем вызова функции WinApi SetWindowCompositionAttribute.

Для оптимальной работы необходимо актировать опцию "В меню пуск, на панели задач и в центре уведомлений" в списке "Отображать цвет элементов на следующих поверхностях" (Параметры Windows -> Персонализация -> Цвет).